### PR TITLE
refactor: 'FileStorageInfo' to 'CanisterInfo'

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -27,7 +27,7 @@
 			"dependencies": ["logger"]
 		},
 		"logger": {
-			"main": "src/actor_logger/logger.mo",
+			"main": "src/actor_logger/Logger.mo",
 			"type": "motoko",
 			"dependencies": []
 		},

--- a/src/actor_file_storage/FileScalingManager.mo
+++ b/src/actor_file_storage/FileScalingManager.mo
@@ -15,7 +15,7 @@ import ICTypes "../c_types/ic";
 import Health "../libs/health";
 
 actor class FileScalingManager(is_prod : Bool, port : Text) = this {
-	type FileStorageInfo = Types.FileStorageInfo;
+	type CanisterInfo = Types.CanisterInfo;
 	type Status = Types.Status;
 	type ErrInit = Types.ErrInit;
 
@@ -32,14 +32,14 @@ actor class FileScalingManager(is_prod : Bool, port : Text) = this {
 	stable var file_storage_canister_id : Text = "";
 
 	// ------------------------- Storage Data -------------------------
-	private var file_storage_registry = Map.new<Text, FileStorageInfo>();
-	stable var file_storage_registry_stable_storage : [(Text, FileStorageInfo)] = [];
+	private var file_storage_registry = Map.new<Text, CanisterInfo>();
+	stable var file_storage_registry_stable_storage : [(Text, CanisterInfo)] = [];
 
 	// ------------------------- Actor -------------------------
 	private let ic_management_actor : ICManagementActor = actor "aaaaa-aa";
 
 	// ------------------------- File Storage Registry -------------------------
-	public query func get_file_storage_registry() : async [FileStorageInfo] {
+	public query func get_file_storage_registry() : async [CanisterInfo] {
 		return Iter.toArray(Map.vals(file_storage_registry));
 	};
 
@@ -51,7 +51,7 @@ actor class FileScalingManager(is_prod : Bool, port : Text) = this {
 		return file_storage_canister_id;
 	};
 
-	public query func get_current_canister() : async ?FileStorageInfo {
+	public query func get_current_canister() : async ?CanisterInfo {
 		switch (Map.get(file_storage_registry, thash, file_storage_canister_id)) {
 			case (?canister) {
 				return ?canister;
@@ -128,7 +128,7 @@ actor class FileScalingManager(is_prod : Bool, port : Text) = this {
 		let principal = Principal.fromActor(file_storage_actor);
 		file_storage_canister_id := Principal.toText(principal);
 
-		let canister_child : FileStorageInfo = {
+		let canister_child : CanisterInfo = {
 			created = Time.now();
 			id = file_storage_canister_id;
 			name = "file_storage";
@@ -145,7 +145,7 @@ actor class FileScalingManager(is_prod : Bool, port : Text) = this {
 	};
 
 	system func postupgrade() {
-		file_storage_registry := Map.fromIter<Text, FileStorageInfo>(file_storage_registry_stable_storage.vals(), thash);
+		file_storage_registry := Map.fromIter<Text, CanisterInfo>(file_storage_registry_stable_storage.vals(), thash);
 
 		file_storage_registry_stable_storage := [];
 	};

--- a/src/actor_file_storage/types.mo
+++ b/src/actor_file_storage/types.mo
@@ -63,7 +63,7 @@ module {
 		files_size : Int;
 	};
 
-	public type FileStorageInfo = {
+	public type CanisterInfo = {
 		created : Int;
 		id : Text;
 		name : Text;

--- a/src/actor_logger/types.mo
+++ b/src/actor_logger/types.mo
@@ -1,8 +1,6 @@
 module {
-	public type Time = Int;
-
 	public type CanisterInfo = {
-		created : Time;
+		created : Int;
 		id : Text;
 		name : Text;
 		parent_name : Text;

--- a/src/actor_username_registry/UsernameRegistry.mo
+++ b/src/actor_username_registry/UsernameRegistry.mo
@@ -39,9 +39,9 @@ actor UsernameRegistry = {
 	type ICManagementActor = ICTypes.Self;
 
 	// ------------------------- Variables -------------------------
-	let VERSION : Nat = 4; // The Version in Production
 	let ACTOR_NAME : Text = "UsernameRegistry";
 	let CYCLE_AMOUNT : Nat = 1_000_000_000_000;
+	let VERSION : Nat = 5; // The Version in Production
 
 	stable var creator_canister_id = "";
 
@@ -118,7 +118,7 @@ actor UsernameRegistry = {
 	};
 
 	// Get Info by Username
-	public query ({}) func get_info_by_username(username : Username) : async Result.Result<UsernameInfo, ErrUsername> {
+	public query func get_info_by_username(username : Username) : async Result.Result<UsernameInfo, ErrUsername> {
 		switch (usernames_info.get(username)) {
 			case (?info) {
 				#ok(info);


### PR DESCRIPTION
This commit includes a significant refactor of the codebase. The type 'FileStorageInfo' has been renamed to 'CanisterInfo' across multiple files, reflecting its more general usage. This change affects variable names, function return types and dependencies. Additionally, the version number in UsernameRegistry has been incremented and an unnecessary parameter removed from a query function.